### PR TITLE
Fix #28 Function openssl_free_key() is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "yiisoft/composer-config-plugin": "^1.0@dev",
         "yiisoft/di": "^3.0@dev",
         "yiisoft/log": "^3.0@dev",
-        "yiisoft/router-fastroute": "3.0.x-dev"
+        "yiisoft/router-fastroute": "^3.0@dev"
     },
     "suggest": {
         "web-token/jwt-checker": "required for JWS, JWT or JWK related flows like OpenIDConnect",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "yiisoft/cache": "^3.0@dev",
         "yiisoft/composer-config-plugin": "^1.0@dev",
         "yiisoft/di": "^3.0@dev",
-        "yiisoft/log": "^3.0@dev"
+        "yiisoft/log": "^3.0@dev",
+        "yiisoft/router-fastroute": "3.0.x-dev"
     },
     "suggest": {
         "web-token/jwt-checker": "required for JWS, JWT or JWK related flows like OpenIDConnect",

--- a/src/Signature/RsaSha.php
+++ b/src/Signature/RsaSha.php
@@ -101,7 +101,9 @@ final class RsaSha extends BaseMethod
         // Sign using the key
         openssl_sign($baseString, $signature, $privateKeyId, $this->algorithm);
         // Release the key resource
-        openssl_free_key($privateKeyId);
+        if (PHP_MAJOR_VERSION < 8) {
+            openssl_free_key($privateKeyId);
+        }
 
         return base64_encode($signature);
     }

--- a/src/Signature/RsaSha.php
+++ b/src/Signature/RsaSha.php
@@ -102,7 +102,7 @@ final class RsaSha extends BaseMethod
         openssl_sign($baseString, $signature, $privateKeyId, $this->algorithm);
         // Release the key resource
         if (PHP_MAJOR_VERSION < 8) {
-            openssl_free_key($privateKeyId);
+            openssl_pkey_free($privateKeyId);
         }
 
         return base64_encode($signature);
@@ -151,7 +151,9 @@ final class RsaSha extends BaseMethod
         // Check the computed signature against the one passed in the query
         $verificationResult = openssl_verify($baseString, $decodedSignature, $publicKeyId, $this->algorithm);
         // Release the key resource
-        openssl_free_key($publicKeyId);
+        if (PHP_MAJOR_VERSION < 8) {
+            openssl_pkey_free($publicKeyId);
+        }
 
         return $verificationResult == 1;
     }

--- a/tests/Signature/RsaShaTest.php
+++ b/tests/Signature/RsaShaTest.php
@@ -58,10 +58,6 @@ class RsaShaTest extends TestCase
      */
     public function testVerify(): void
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->markTestSkipped('The test should be fixed in PHP 8.0.');
-        }
-
         $signatureMethod = new RsaSha(OPENSSL_ALGO_SHA1);
         $signatureMethod->setPrivateCertificateFile(dirname(__DIR__, 1) . '/Data/private.key');
         $signatureMethod->setPublicCertificateFile(dirname(__DIR__, 1) . '/Data/public.key');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 